### PR TITLE
run-blktests: rename the runs-on resource

### DIFF
--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-and-test-kernel:
     #This step runs in a container in the k8s cluster 
-    runs-on: arc-vm-shinichiro-linux-block
+    runs-on: arc-vm-linux-blktests
     steps:
       - name: Checkout blktests-ci
         uses: actions/checkout@v4


### PR DESCRIPTION
Renameing the runs-on resource for the new organization and repository structure.