### PR TITLE
run-blktests: fix md/001

### DIFF
--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -82,7 +82,6 @@ jobs:
             device-mapper \
             ktls-utils \
             dosfstools \
-            mdadm \
             bc \
             libnl3-cli \
             cryptsetup \
@@ -92,8 +91,17 @@ jobs:
             jq \
             nvme-cli \
             git \
-            wget
+            wget \
+            pkgconf \
+            libudev-devel
 
+            git clone https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git
+            cd mdadm
+            git checkout d764c4829947923142a83251296d04edaee7d2f7
+            make -j$(nproc)
+            sudo make install
+
+            cd -
             git clone https://github.com/linux-blktests/blktests.git
 
             cd blktests


### PR DESCRIPTION
md/001 is failing with every run.
mdadm has a buffer overflow in v4.3 and was fixed with this commit: https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/?id=7f960c3bd050e76f8bf0a8a0c8fbdcbaa565fc78

The Fedora packages ship v4.3.
We are now compiling and installing mdadm from source with the most recent commit. The v4.4 release does not compile.