### PR TITLE
Add device list to kubevirt-action

### DIFF
--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Run in VM
         uses: ./blktests-ci/.github/actions/kubevirt-action
         with:
+          host_devices: "nvme-wdc-zn540,nvme-wdc-sn640"
           kernel_version: ${{ env.KERNEL_VERSION }}
           vm_artifact_upload_dir: blktests/results
           run_cmds: |


### PR DESCRIPTION
We need to specify the devices that are passed though to the VM when running the tests. The kubevirt-action should not be responsible for picking the testing devices.