### PR TITLE
run-blktests: pass proxy build args to docker build

### DIFF
--- a/.github/workflows/run-blktests.yml
+++ b/.github/workflows/run-blktests.yml
@@ -35,6 +35,9 @@ jobs:
           docker build \
             --build-arg KERNEL_TREE=${KERNEL_TREE} \
             --build-arg KERNEL_REF=${KERNEL_REF} \
+            --build-arg http_proxy \
+            --build-arg https_proxy \
+            --build-arg no_proxy \
             -t linux-kernel-containerdisk \
             -f Dockerfile.linux-kernel-containerdisk . 2>&1 | tee build.log
           #Setting KERNEL_VERSION var which is latern needed for notifying the VM what kernel to pick up


### PR DESCRIPTION
docker build does not pass the runner pod's proxy environment into the build's RUN steps, so on clusters behind mitmproxy the Dockerfile never saw a proxy, silently skipped installing the proxy CA and the build failed with "self-signed certificate in certificate chain" in dnf.

Pass the proxy build args explicitly.
On clusters without mitmproxy the variables are empty and the build is unaffected.